### PR TITLE
Added some memory deallocation to allow SimpleGUI instances to be created / destroyed

### DIFF
--- a/SimpleGUI/include/SimpleGUI.h
+++ b/SimpleGUI/include/SimpleGUI.h
@@ -83,7 +83,9 @@ public:
 	};
 public:
 	SimpleGUI(App* app);
+	~SimpleGUI();
 	bool	isSelected() { return selectedControl != NULL; }
+	Control* getSelectedControl() { return selectedControl; };
 	std::vector<Control*>& getControls() { return controls; }	
 	
 	bool	onMouseDown(MouseEvent event);
@@ -97,6 +99,8 @@ public:
 	
 	bool	isEnabled();
 	void	setEnabled(bool state);
+	void	removeControl( Control* controlToRemove );
+
 
 	FloatVarControl* 	addParam(const std::string& paramName, float* var, float min=0, float max=1, float defaultValue = 0);
 	IntVarControl*		addParam(const std::string& paramName, int* var, int min=0, int max=1, int defaultValue = 0);

--- a/SimpleGUI/src/SimpleGUI.cpp
+++ b/SimpleGUI/src/SimpleGUI.cpp
@@ -384,7 +384,9 @@ Vec2f FloatVarControl::draw(Vec2f pos) {
 		(pos + SimpleGUI::labelSize + SimpleGUI::sliderSize + SimpleGUI::padding*2).y)
 	);	
 	
-	gl::drawString(name, pos, SimpleGUI::textColor, SimpleGUI::textFont);
+	std::stringstream ss;
+	ss <<  name << " " << *this->var;
+	gl::drawString(ss.str(), pos, SimpleGUI::textColor, SimpleGUI::textFont);
 	
 	gl::color(SimpleGUI::darkColor);
 	gl::drawSolidRect(activeArea);
@@ -461,8 +463,10 @@ Vec2f IntVarControl::draw(Vec2f pos) {
 							(pos + SimpleGUI::sliderSize + SimpleGUI::padding).x, 
 							(pos + SimpleGUI::labelSize + SimpleGUI::sliderSize + SimpleGUI::padding*2).y)
 					  );	
-	
-	gl::drawString(name, pos, SimpleGUI::textColor, SimpleGUI::textFont);
+					  
+	std::stringstream ss;
+	ss <<  name << " " << *this->var;
+	gl::drawString(ss.str(),pos, SimpleGUI::textColor, SimpleGUI::textFont);
 	
 	gl::color(SimpleGUI::darkColor);
 	gl::drawSolidRect(activeArea);

--- a/SimpleGUI/src/SimpleGUI.cpp
+++ b/SimpleGUI/src/SimpleGUI.cpp
@@ -54,6 +54,14 @@ SimpleGUI::SimpleGUI(App* app) {
 	init(app);
 	enabled = true;
 }
+
+SimpleGUI::~SimpleGUI() {
+	std::cout << "Removing gui " << std::endl;
+	selectedControl = NULL;
+	ci::app::App::get()->unregisterMouseDown( cbMouseDown );
+	ci::app::App::get()->unregisterMouseUp( cbMouseUp );
+	ci::app::App::get()->unregisterMouseDrag( cbMouseDrag );
+}
 	
 void SimpleGUI::init(App* app) {	
 	textFont = Font(loadResource("pf_tempesta_seven.ttf"), 8);
@@ -133,14 +141,26 @@ PanelControl* SimpleGUI::addPanel() {
 	controls.push_back(control);
 	return control;
 }
+
+void SimpleGUI::removeControl( Control* controlToRemove ) {
+	std::vector<Control*>::iterator it = controls.begin();
+	while( it!= controls.end() ) {
+		Control* control = *it;
+		if( control == controlToRemove ) {
+			controls.erase( it );
+			return;
+		}
+		++it;
+	}
+}
 	
 void SimpleGUI::draw() {	
 	if (!enabled) return;
 
 	gl::pushMatrices();
 	gl::setMatricesWindow(getWindowSize());
-	gl::disableDepthRead();	
-	gl::disableDepthWrite();		
+	gl::disableDepthRead();
+	gl::disableDepthWrite();
 	gl::enableAlphaBlending();
 
 	Vec2f position = Vec2f(spacing, spacing);
@@ -242,13 +262,17 @@ bool SimpleGUI::onMouseDown(MouseEvent event) {
 	
 	std::vector<Control*>::iterator it = controls.begin();	
 	while(it != controls.end()) {
-		Control* control = *it++;
-		if (control->activeArea.contains(event.getPos())) {
-			selectedControl = control;
-			selectedControl->onMouseDown(event);	
-			return true;
+		Control* control = *it;
+		if(control) {
+			if (control->activeArea.contains(event.getPos())) {
+				selectedControl = control;
+				selectedControl->onMouseDown(event);
+				return true;
+			}
 		}
+		it++;
 	}	
+
 	return false;
 }
 
@@ -301,6 +325,8 @@ Control* SimpleGUI::getControlByName(const std::string& name) {
 	}
 	return NULL;
 }
+
+
 
 //-----------------------------------------------------------------------------
 	


### PR DESCRIPTION
I added some simple unregistering of events on the destructor function, as well as a matching removeControl method.
Additionally, and perhaps this is not by design it seemed useful. I also made float and int value labels display the current value.

![Screenshot](http://farm7.static.flickr.com/6031/6235261098_d2af226f1f_o.png)
